### PR TITLE
fix(docs): Rearrange tetikus position

### DIFF
--- a/README-ID.md
+++ b/README-ID.md
@@ -54,8 +54,8 @@ mohon untuk mengurutkannya secara alfabetis naik.
 
 - [React Datepicker Component](https://github.com/adibfirman/react-datepicker) oleh [Adib Firman](https://github.com/adibfirman) - Sebuah _datepicker_ mengagumkan untuk aplikasi React Anda, dibangun dengan _Framer Motion_ - React, _Datepicker_
 - [React Web Monetization UI](https://github.com/ekafyi/react-web-monetization-ui) oleh [Eka](https://github.com/ekafyi) - Komponen antarmuka yang berguna untuk API Web Monetization pada React - React, Monetization
-- [Vue Scheduler](https://github.com/burhanahmeed/vue-daily-schedule) oleh [Burhan](https://github.com/burhanahmeed) - Sebuah komponen penjadwalan harian yang mudah untuk VueJS / NuxtJS - Vue, Scheduler
 - [Tetikus](https://github.com/Namchee/tetikus) oleh [Namchee](https://github.com/Namchee) - (Eksperimental) Sebuah komponen kursor sederhana yang dapat dikustomisasi untuk Vue 3 ✌️ - Vue, _Custom Cursor_
+- [Vue Scheduler](https://github.com/burhanahmeed/vue-daily-schedule) oleh [Burhan](https://github.com/burhanahmeed) - Sebuah komponen penjadwalan harian yang mudah untuk VueJS / NuxtJS - Vue, Scheduler
 
 ### Bahasa Pemrograman
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ please sort it in ascending order.
 
 - [React Datepicker Component](https://github.com/adibfirman/react-datepicker) by [Adib Firman](https://github.com/adibfirman) - An awesome Datepicker for your React APP, built in with Framer Motion - React, Datepicker
 - [React Web Monetization UI](https://github.com/ekafyi/react-web-monetization-ui) by [Eka](https://github.com/ekafyi) - Handy UI components to use with the Web Monetization API in React - React, Monetization
-- [Vue Scheduler](https://github.com/burhanahmeed/vue-daily-schedule) by [Burhan](https://github.com/burhanahmeed) - A straightforward daily scheduler component for VueJS / NuxtJS - Vue, Scheduler
 - [Tetikus](https://github.com/Namchee/tetikus) by [Namchee](https://github.com/Namchee) - (Experimental) A small custom cursor component for Vue 3 ✌️ - Vue, Custom Cursor
+- [Vue Scheduler](https://github.com/burhanahmeed/vue-daily-schedule) by [Burhan](https://github.com/burhanahmeed) - A straightforward daily scheduler component for VueJS / NuxtJS - Vue, Scheduler
 
 ### Programming Language
 


### PR DESCRIPTION
As the document states that all projects should be sorted with alphabetically ascending order, `tetikus` should have higher priority than `Vue Scheduler`.