### PR TITLE
update resir014.xyz to Next.js

### DIFF
--- a/README-ID.md
+++ b/README-ID.md
@@ -57,7 +57,7 @@ mohon untuk mengurutkannya secara alfabetis naik.
 - [hanihusam.com](https://github.com/hanihusam/hanihusam.com) oleh [Hani Husamuddin](https://github.com/hanihusam) - React, Next.js
 - [iyansr.id](https://github.com/iyansr/iyansr.id-reborn) oleh [Iyan Saputra](https://github.com/iyansr) - React, Next.js, Framer Motion, Strapi
 - [Nusendra's blog](https://github.com/nusendra/blog) oleh [Nusendra](https://github.com/nusendra) - Svelte, Sapper
-- [resir014.xyz](https://github.com/resir014/resir014.xyz) oleh [Resi Respati](https://github.com/resir014) - React, Gatsby
+- [resir014.xyz](https://github.com/resir014/resir014.xyz) oleh [Resi Respati](https://github.com/resir014) - React, Next.js
 - [sonnylab.com](https://github.com/sonnylazuardi/sonnylab.com) oleh [Sonny Lazuardi](https://github.com/sonnylazuardi) - React, Gatsby, Framer Motion
 - [zainfathoni.com](https://github.com/zainfathoni/www.zainfathoni.com) oleh [Zain Fathoni](https://github.com/zainfathoni) - React, Gatsby
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ please sort it in ascending order.
 - [hanihusam.com](https://github.com/hanihusam/hanihusam.com) by [Hani Husamuddin](https://github.com/hanihusam) - React, Next.js
 - [iyansr.id](https://github.com/iyansr/iyansr.id-reborn) by [Iyan Saputra](https://github.com/iyansr) - React, Next.js, Framer Motion, Strapi
 - [Nusendra's blog](https://github.com/nusendra/blog) by [Nusendra](https://github.com/nusendra) - Svelte, Sapper
-- [resir014.xyz](https://github.com/resir014/resir014.xyz) by [Resi Respati](https://github.com/resir014) - React, Gatsby
+- [resir014.xyz](https://github.com/resir014/resir014.xyz) by [Resi Respati](https://github.com/resir014) - React, Next.js
 - [sonnylab.com](https://github.com/sonnylazuardi/sonnylab.com) by [Sonny Lazuardi](https://github.com/sonnylazuardi) - React, Gatsby, Framer Motion
 - [zainfathoni.com](https://github.com/zainfathoni/www.zainfathoni.com) by [Zain Fathoni](https://github.com/zainfathoni) - React, Gatsby
 


### PR DESCRIPTION
Since <https://resir014.xyz> has been [migrated to Next.js][1], I'm updating this list to reflect it.

[1]: https://github.com/resir014/resir014.xyz/pull/138